### PR TITLE
Добавлен запускатель oscript. Fix xDrivenDevelopment/1c-syntax#26

### DIFF
--- a/lib/language-1c-bsl.coffee
+++ b/lib/language-1c-bsl.coffee
@@ -1,4 +1,5 @@
 {CompositeDisposable} = require 'atom'
+{EventEmitter} = require 'events'
 
 module.exports = Language1cBSL =
   subscriptions: null
@@ -17,3 +18,39 @@ module.exports = Language1cBSL =
     scope = editor.getLastCursor().getScopeDescriptor().toString()
     if scope==".source.bsl .string.quoted.double.bsl"
       editor.insertText('|')
+
+  provideBuilder: ->
+    class Language1cBSLBuildProvider extends EventEmitter
+
+      constructor: (@cwd) ->
+
+      getNiceName: ->
+        '1C (BSL)'
+
+      isEligible: ->
+        yes
+
+      settings: ->
+        [
+          run =
+            name: 'OneScript: run',
+            sh: false,
+            exec: 'oscript',
+            args: [ '-encoding=utf-8', '{FILE_ACTIVE}' ],
+            errorMatch: [
+                '^\\{Модуль (?<file>.+) / Ошибка в строке: (?<line>[0-9]+) / (?<message>.*)\\}$'
+            ]
+
+          compile =
+            name: 'OneScript: compile',
+            sh: false,
+            exec: 'oscript',
+            args: [ '-encoding=utf-8', '-compile', '{FILE_ACTIVE}' ]
+
+          make =
+            name: 'OneScript: make',
+            sh: false,
+            exec: 'oscript',
+            args: [ '-encoding=utf-8', '-make', '{FILE_ACTIVE}' ]
+
+        ]

--- a/lib/language-1c-bsl.coffee
+++ b/lib/language-1c-bsl.coffee
@@ -51,6 +51,6 @@ module.exports = Language1cBSL =
             name: 'OneScript: make',
             sh: false,
             exec: 'oscript',
-            args: [ '-encoding=utf-8', '-make', '{FILE_ACTIVE}' ]
+            args: [ '-encoding=utf-8', '-make', '{FILE_ACTIVE}', '{FILE_ACTIVE_NAME_BASE}.exe' ]
 
         ]

--- a/package.json
+++ b/package.json
@@ -14,5 +14,13 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "providedServices": {
+      "builder": {
+        "description": "Builds 1C (BSL) files with OneScript",
+        "versions": {
+          "2.0.0": "provideBuilder"
+        }
+      }
+    }
 }


### PR DESCRIPTION
Добавлен функционал для запуска oscript.
Для работы запускатора необходим пакет [build](https://atom.io/packages/build) - необходимо отразить это в readme.

Доступно 3 команды. Указатель на строку ошибки пока не работает. Возможно из-за ограничения на расположение файла по `cwd` https://github.com/noseglid/atom-build/blob/master/README.md#error-matching

Так же надо убрать отладочные сообщения и скорректировать функцию IsEligeble.

Думаю, @artbear будет рад :)

![1](https://cloud.githubusercontent.com/assets/1132840/11742406/baad3af2-a010-11e5-81ca-15bbfbf7c5fb.PNG)
![2](https://cloud.githubusercontent.com/assets/1132840/11742392/9fb1ee28-a010-11e5-891b-9b35750648f9.png)
![3](https://cloud.githubusercontent.com/assets/1132840/11742395/a1698258-a010-11e5-856e-1231d981a567.PNG)

xDrivenDevelopment/1c-syntax#26