### PR TITLE
Добавлена вставка | при переносе строки

### DIFF
--- a/keymaps/language-1c-bsl.cson
+++ b/keymaps/language-1c-bsl.cson
@@ -1,0 +1,2 @@
+"atom-text-editor[data-grammar='source bsl']":
+  'enter': 'language-1c-bsl:addpipe'

--- a/lib/language-1c-bsl.coffee
+++ b/lib/language-1c-bsl.coffee
@@ -1,0 +1,19 @@
+{CompositeDisposable} = require 'atom'
+
+module.exports = Language1cBSL =
+  subscriptions: null
+
+  activate: (state) ->
+
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'language-1c-bsl:addpipe': => @addpipe()
+
+  deactivate: ->
+    @subscriptions.dispose()
+
+  addpipe: ->
+    editor = atom.workspace.getActiveTextEditor()
+    editor.insertText('\n')
+    scope = editor.getLastCursor().getScopeDescriptor().toString()
+    if scope==".source.bsl .string.quoted.double.bsl"
+      editor.insertText('|')

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "language-1c-bsl",
+  "main": "./lib/language-1c-bsl",
   "author": "Nikita Gryzlov <nixel2007@gmail.com>",
   "version": "1.0.7",
   "description": "Provides syntax highlighting for 1C:Enterprise 8 (1S:Enterprise 8)",


### PR DESCRIPTION
Реализация в рамках xDrivenDevelopment/1c-syntax#48

Реализовано в пакете, дополнительных настроек редактора производить не нужно.