### PR TITLE
Тест грамматики

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+git:
+  depth: 10
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+env:
+  global:
+    - APM_TEST_PACKAGES="linter"
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot
+
+branches:
+  only:
+    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: "{build}"
+
+platform: x64
+
+branches:
+    only:
+      - master
+
+skip_tags: true
+
+environment:
+  APM_TEST_PACKAGES:
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+install:
+  - ps: Install-Product node 5
+
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+test: off
+deploy: off

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
-    "atom-grammar-test": "^0.5.1"
+    "atom-grammar-test": "^0.6.0"
   },
   "package-deps": [
     "linter"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "atom-linter": "^4.0.1",
     "atom-package-deps": "^4.0.1"
   },
+  "devDependencies": {
+    "atom-grammar-test": "^0.5.1"
+  },
   "package-deps": [
     "linter"
   ],

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -2,6 +2,60 @@
 #Область ИмяОбласти  
 // ^ keyword.other.section.bsl
 //       ^ entity.name.section.bsl
-// < comment.line.double-slash.bsl
+
+// Комментарий процедуры
+// ^ comment.line.double-slash.bsl
+Процедура ИмяПроцедуры(Знач ПараметрСКонстантой, ОбычныйПараметр, ПараметрСДефолтнымЧисловымЗначением = 0) Экспорт
+// ^ storage.type.bsl
+//        ^ entity.name.function.bsl
+//                     ^ storage.modifier.bsl
+//                          ^ variable.parameter.bsl
+//                                             ^ keyword.operator.bsl
+//                                               ^ variable.parameter.bsl
+//                                                                                                    ^ keyword.operator.comparison.bsl
+//                                                                                                      ^ constant.numeric.bsl
+//                                                                                                         ^ storage.modifier.bsl
+
+    А = 0;
+//    ^ keyword.operator.comparison.bsl
+//      ^ constant.numeric.bsl
+//       ^ keyword.operator.bsl
+
+    Б = "текст с экраннированной "" кавычкой";
+//       ^ string.quoted.double.bsl
+//                               ^ constant.character.escape.bsl
+    
+    Если А = 0 Тогда
+//  ^ keyword.control.conditional.bsl
+//         ^ keyword.operator.comparison.bsl
+//             ^ keyword.control.conditional.bsl
+
+        ОбычныйПараметр = Истина;
+//                        ^ constant.language.bsl
+
+    Иначе
+//  ^ keyword.control.conditional.bsl
+        ОбычныйПараметр = Ложь;
+    КонецЕсли;
+//  ^ keyword.control.conditional.bsl
+    
+    Пока ЗначениеЗаполнено(Б) Цикл
+//  ^ keyword.control.repeat.bsl
+//       ^ support.function.bsl
+        Прервать;
+//      ^ keyword.control.repeat.bsl        
+    КонецЦикла;
+//  ^ keyword.control.repeat.bsl
+    
+    НевстроеннаяПроцедура();
+    
+КонецПроцедуры
+// ^ storage.type.bsl
+
+Процедура НевстроеннаяПроцедура()
+    Возврат;
+//  ^ keyword.control.bsl
+КонецПроцедуры
+
 #КонецОбласти
 // ^ keyword.other.section.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -19,18 +19,22 @@
     ОбычныйПараметр,
 //  ^ variable.parameter.bsl
     ПараметрСНекорректнымЗначением = Нелегальщина,
+//                                  ^ not:invalid.illegal.bsl
 //                                   ^ invalid.illegal.bsl
     ПараметрСНекорректнымЗначением =НелегальщинаБезПробела,
 //                                  ^ invalid.illegal.bsl
+//                                                        ^ keyword.operator.bsl
     ПараметрСДефолтнымЧисловымЗначением = 0) Экспорт
 //                                      ^ keyword.operator.comparison.bsl
 //                                        ^ constant.numeric.bsl
 //                                           ^ storage.modifier.bsl
 
-    Б = "текст с экраннированной "" кавычкой";
+    Б = "текст с экраннированной "" кавычкой" + "и конкатенаций";
 //       ^ string.quoted.double.bsl
 //                               ^ constant.character.escape.bsl
-//                                           ^ keyword.operator.bsl
+//                                            ^ keyword.operator.arithmetic.bsl
+//                                              ^ string.quoted.double.bsl
+//                                                              ^ keyword.operator.bsl
 
     В = "многострочная
 //      ^ string.quoted.double.bsl
@@ -45,7 +49,10 @@
 //    ^ keyword.operator.bsl
 
     GUID = 00000000-0000-0000-0000-000000000000;
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.bsl 
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.bsl
+    Число = 0.0;
+//  ^ not:support.function.bsl
+//          ^^^ constant.numeric.bsl
     Если А = 0 Тогда
 //  ^ keyword.control.conditional.bsl
 //         ^ keyword.operator.comparison.bsl
@@ -69,7 +76,7 @@
 //  ^ keyword.control.repeat.bsl
     
     НевстроеннаяПроцедура();
-//  x^ support.function.bsl
+//  ^ not:support.function.bsl
     
 КонецПроцедуры
 // <- storage.type.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -66,7 +66,7 @@
 	|	И ВЫРАЗИТЬ(Таблица.Поле КАК СТРОКА) <> """"
 	|	И Таблица.Поле <> ""Строка с экраннированной """" кавычкой""
     //|Закомментированная строка
-//  ^ string.quoted.double.bsl comment.line.double-slash.sdbl
+//  ^ string.quoted.double.bsl comment.line.double-slash.bsl
     |// Закомметированная строка внутри запроса с кавычками ""ТЕКСТ""
 //  ^ string.quoted.double.bsl
 //  ^ not:comment.line.double-slash.sdbl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -3,36 +3,54 @@
 // ^ keyword.other.section.bsl
 //       ^ entity.name.section.bsl
 
+Перем А Экспорт;
+//  ^ storage.type.var.bsl
+//          ^ storage.modifier.bsl
+
 // Комментарий процедуры
 // <- comment.line.double-slash.bsl
-Процедура ИмяПроцедуры(Знач ПараметрСКонстантой, ОбычныйПараметр, ПараметрСДефолтнымЧисловымЗначением = 0) Экспорт
+Процедура ИмяПроцедуры(
 // <- storage.type.bsl
 //        ^ entity.name.function.bsl
-//                     ^ storage.modifier.bsl
-//                          ^ variable.parameter.bsl
-//                                             ^ keyword.operator.bsl
-//                                               ^ variable.parameter.bsl
-//                                                                                                    ^ keyword.operator.comparison.bsl
-//                                                                                                      ^ constant.numeric.bsl
-//                                                                                                         ^ storage.modifier.bsl
-
-    А = 0;
-//    ^ keyword.operator.comparison.bsl
-//      ^ constant.numeric.bsl
-//       ^ keyword.operator.bsl
+    Знач ПараметрСКонстантой,
+//  ^ storage.modifier.bsl
+//       ^ variable.parameter.bsl
+//                          ^ keyword.operator.bsl
+    ОбычныйПараметр,
+//  ^ variable.parameter.bsl
+    ПараметрСНекорректнымЗначением = Нелегальщина,
+//                                   ^ invalid.illegal.bsl
+    ПараметрСНекорректнымЗначением =НелегальщинаБезПробела,
+//                                  ^ invalid.illegal.bsl
+    ПараметрСДефолтнымЧисловымЗначением = 0) Экспорт
+//                                      ^ keyword.operator.comparison.bsl
+//                                        ^ constant.numeric.bsl
+//                                           ^ storage.modifier.bsl
 
     Б = "текст с экраннированной "" кавычкой";
 //       ^ string.quoted.double.bsl
 //                               ^ constant.character.escape.bsl
-    
+
+    В = "многострочная
+//      ^ string.quoted.double.bsl
+    |строка
+//  ^ string.quoted.double.bsl
+    //|это комментарий
+//      ^ comment.line.double-slash.bsl
+    |// а это нет
+//      ^ string.quoted.double.bsl
+    |";
+//   ^ string.quoted.double.bsl
+//    ^ keyword.operator.bsl
+
     Если А = 0 Тогда
 //  ^ keyword.control.conditional.bsl
 //         ^ keyword.operator.comparison.bsl
+//           ^ constant.numeric.bsl
 //             ^ keyword.control.conditional.bsl
 
         ОбычныйПараметр = Истина;
 //                        ^ constant.language.bsl
-
     Иначе
 //  ^ keyword.control.conditional.bsl
         ОбычныйПараметр = Ложь;
@@ -48,6 +66,7 @@
 //  ^ keyword.control.repeat.bsl
     
     НевстроеннаяПроцедура();
+//  x^ support.function.bsl
     
 КонецПроцедуры
 // <- storage.type.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -29,12 +29,15 @@
 //                                        ^ constant.numeric.bsl
 //                                           ^ storage.modifier.bsl
 
-    Б = "текст с экраннированной "" кавычкой" + "и конкатенаций";
+    Б = "текст с экраннированной "" кавычкой" + "и конкатенаций""";
 //       ^ string.quoted.double.bsl
-//                               ^ constant.character.escape.bsl
-//                                            ^ keyword.operator.arithmetic.bsl
+//                               ^^ constant.character.escape.bsl
+//                               ^^ constant.character.escape.bsl
+//                                 ^ not:constant.character.escape.bsl
 //                                              ^ string.quoted.double.bsl
-//                                                              ^ keyword.operator.bsl
+//                                                             ^^ constant.character.escape.bsl
+//                                                               ^ not:constant.character.escape.bsl
+//                                                                ^ keyword.operator.bsl
 
     В = "многострочная
 //      ^ string.quoted.double.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -133,6 +133,9 @@
 //                      ^^^^^ support.function.bsl
 //                           ^ not:support.function.bsl	
 	
+    ПрефиксЗначениеЗаполненоПостфикс = "";
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not:support.function.bsl
+	
 КонецПроцедуры
 // <- storage.type.bsl
 

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -28,10 +28,8 @@
 //                                      ^ keyword.operator.comparison.bsl
 //                                        ^ constant.numeric.bsl
 //                                           ^ storage.modifier.bsl
-
     Б = "текст с экраннированной "" кавычкой" + "и конкатенаций""";
 //       ^ string.quoted.double.bsl
-//                               ^^ constant.character.escape.bsl
 //                               ^^ constant.character.escape.bsl
 //                                 ^ not:constant.character.escape.bsl
 //                                              ^ string.quoted.double.bsl
@@ -50,6 +48,37 @@
     |";
 //   ^ string.quoted.double.bsl
 //    ^ keyword.operator.bsl
+
+    Г = "";
+//      ^^ string.quoted.double.bsl
+
+    ТекстЗапроса =
+    "ВЫБРАТЬ
+//  ^^ string.quoted.double.bsl
+//   ^ keyword.control.sdbl
+	|	Таблица.Поле КАК Поле,
+	|	МАКСИМУМ(Таблица.Поле2) КАК Поле2
+	|ИЗ
+	|	Таблица КАК Таблица
+	|ГДЕ
+	|	Таблица.Поле = 0
+	|	И Таблица.Поле <> ""Строка""
+	|	И ВЫРАЗИТЬ(Таблица.Поле КАК СТРОКА) <> """"
+	|	И Таблица.Поле <> ""Строка с экраннированной """" кавычкой""
+    //|Закомментированная строка
+//  ^ string.quoted.double.bsl comment.line.double-slash.sdbl
+    |// Закомметированная строка внутри запроса с кавычками ""ТЕКСТ""
+//  ^ string.quoted.double.bsl
+//  ^ not:comment.line.double-slash.sdbl
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.sdbl
+	|СГРУППИРОВАТЬ ПО
+	|	Поле
+    |//АВТОУПОРЯДОЧИВАНИЕ";
+//  ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.bsl
+//  ^ not:comment.line.double-slash.sdbl
+//   ^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.sdbl
+//                       ^ not:comment.line.double-slash.sdbl
+//                        ^ keyword.operator.bsl
 
     GUID = 00000000-0000-0000-0000-000000000000;
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -44,6 +44,8 @@
 //   ^ string.quoted.double.bsl
 //    ^ keyword.operator.bsl
 
+    GUID = 00000000-0000-0000-0000-000000000000;
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.bsl 
     Если А = 0 Тогда
 //  ^ keyword.control.conditional.bsl
 //         ^ keyword.operator.comparison.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -101,11 +101,14 @@
     КороткаяДата = '00010101';
 //                 ^^^^^^^^^^ constant.other.date.bsl
 
-    Если А = 0 Тогда
+    Если А = 0 И НЕ Число <= 0 Тогда
 //  ^ keyword.control.conditional.bsl
 //         ^ keyword.operator.comparison.bsl
 //           ^ constant.numeric.bsl
-//             ^ keyword.control.conditional.bsl
+//             ^ keyword.operator.logical.bsl
+//               ^^ keyword.operator.logical.bsl
+//                        ^^ keyword.operator.comparison.bsl
+//                             ^ keyword.control.conditional.bsl
 
         ОбычныйПараметр = Истина;
 //                        ^ constant.language.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -8,8 +8,15 @@
 //    ^ variable.bsl
 //      ^ storage.modifier.bsl
 
+#Если Сервер Тогда 
+// <- keyword.other.preprocessor.bsl
+//    ^^^^^^ keyword.other.preprocessor.bsl
+
 // Комментарий процедуры
 // <- comment.line.double-slash.bsl
+&НаСервере
+// <- storage.modifier.bsl
+// ^ storage.modifier.bsl
 Процедура ИмяПроцедуры(
 // <- storage.type.bsl
 //        ^ entity.name.function.bsl
@@ -118,6 +125,10 @@
     Возврат;
 //  ^ keyword.control.bsl
 КонецПроцедуры
+
+#КонецЕсли
+// <- keyword.other.preprocessor.bsl
+// ^ keyword.other.preprocessor.bsl
 
 #КонецОбласти
 // <- keyword.other.section.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -94,6 +94,12 @@
     Число = 0.0;
 //  ^ not:support.function.bsl
 //          ^^^ constant.numeric.bsl
+	
+    Дата = '000101010000';
+//         ^^^^^^^^^^^^^^ constant.other.date.bsl
+    КороткаяДата = '00010101';
+//                 ^^^^^^^^^^ constant.other.date.bsl
+
     Если А = 0 Тогда
 //  ^ keyword.control.conditional.bsl
 //         ^ keyword.operator.comparison.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -1,12 +1,12 @@
 // SYNTAX TEST "source.bsl"
-#Область ИмяОбласти  
+#Область ИмяОбласти
 // ^ keyword.other.section.bsl
 //       ^ entity.name.section.bsl
 
 // Комментарий процедуры
-// ^ comment.line.double-slash.bsl
+// <- comment.line.double-slash.bsl
 Процедура ИмяПроцедуры(Знач ПараметрСКонстантой, ОбычныйПараметр, ПараметрСДефолтнымЧисловымЗначением = 0) Экспорт
-// ^ storage.type.bsl
+// <- storage.type.bsl
 //        ^ entity.name.function.bsl
 //                     ^ storage.modifier.bsl
 //                          ^ variable.parameter.bsl
@@ -50,7 +50,7 @@
     НевстроеннаяПроцедура();
     
 КонецПроцедуры
-// ^ storage.type.bsl
+// <- storage.type.bsl
 
 Процедура НевстроеннаяПроцедура()
     Возврат;
@@ -58,4 +58,4 @@
 КонецПроцедуры
 
 #КонецОбласти
-// ^ keyword.other.section.bsl
+// <- keyword.other.section.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -1,0 +1,7 @@
+// SYNTAX TEST "source.bsl"
+#Область ИмяОбласти  
+// ^ keyword.other.section.bsl
+//       ^ entity.name.section.bsl
+// < comment.line.double-slash.bsl
+#КонецОбласти
+// ^ keyword.other.section.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -1,11 +1,11 @@
 // SYNTAX TEST "source.bsl"
 #Область ИмяОбласти
-// ^ keyword.other.section.bsl
+// <- keyword.other.section.bsl
 //       ^ entity.name.section.bsl
 
 Перем А Экспорт;
-//  ^ storage.type.var.bsl
-//          ^ storage.modifier.bsl
+// <- storage.type.var.bsl
+//      ^ storage.modifier.bsl
 
 // Комментарий процедуры
 // <- comment.line.double-slash.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -124,7 +124,14 @@
     
     НевстроеннаяПроцедура();
 //  ^ not:support.function.bsl
-    
+
+    НовыйОбъект = Новый ТаблицаЗначений;
+//                ^^^^^ support.function.bsl
+//                     ^ not:support.function.bsl	
+    НовыйОбъектСкобка = Новый("ТаблицаЗначений");
+//                      ^^^^^ support.function.bsl
+//                           ^ not:support.function.bsl	
+	
 КонецПроцедуры
 // <- storage.type.bsl
 

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -1,6 +1,7 @@
 // SYNTAX TEST "source.bsl"
 #Область ИмяОбласти
 // <- keyword.other.section.bsl
+// ^ keyword.other.section.bsl
 //       ^ entity.name.section.bsl
 
 Перем А Экспорт;
@@ -132,3 +133,4 @@
 
 #КонецОбласти
 // <- keyword.other.section.bsl
+// ^ keyword.other.section.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -5,6 +5,7 @@
 
 Перем А Экспорт;
 // <- storage.type.var.bsl
+//    ^ variable.bsl
 //      ^ storage.modifier.bsl
 
 // Комментарий процедуры

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -96,8 +96,8 @@
 //          ^^^ constant.numeric.bsl
 //              ^ keyword.operator.arithmetic.bsl
 	
-    Дата = '000101010000';
-//         ^^^^^^^^^^^^^^ constant.other.date.bsl
+    Дата = '00010101000000';
+//         ^^^^^^^^^^^^^^^^ constant.other.date.bsl
     КороткаяДата = '00010101';
 //                 ^^^^^^^^^^ constant.other.date.bsl
 

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -30,6 +30,7 @@
     Б = "текст с экраннированной "" кавычкой";
 //       ^ string.quoted.double.bsl
 //                               ^ constant.character.escape.bsl
+//                                           ^ keyword.operator.bsl
 
     В = "многострочная
 //      ^ string.quoted.double.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.bsl
+++ b/spec/fixtures/grammar/syntax_test_bsl.bsl
@@ -91,9 +91,10 @@
 
     GUID = 00000000-0000-0000-0000-000000000000;
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.bsl
-    Число = 0.0;
+    Число = 0.0 * 100;
 //  ^ not:support.function.bsl
 //          ^^^ constant.numeric.bsl
+//              ^ keyword.operator.arithmetic.bsl
 	
     Дата = '000101010000';
 //         ^^^^^^^^^^^^^^ constant.other.date.bsl

--- a/spec/fixtures/grammar/syntax_test_bsl.os
+++ b/spec/fixtures/grammar/syntax_test_bsl.os
@@ -1,0 +1,3 @@
+// SYNTAX TEST "source.bsl"
+#Использовать cmdline
+// <- keyword.control.import.bsl

--- a/spec/fixtures/grammar/syntax_test_sdbl.txt
+++ b/spec/fixtures/grammar/syntax_test_sdbl.txt
@@ -1,0 +1,13 @@
+// SYNTAX TEST "source.sdbl"
+ВЫБРАТЬ
+// <- keyword.control.sdbl
+// Комментарий запроса
+// <- comment.line.double-slash.sdbl
+    "Многострочная
+//  ^ string.quoted.double.sdbl
+    // это Комментарий
+//  ^ comment.line.double-slash.sdbl
+    с экранированной "" кавычкой
+//                   ^^ constant.character.escape.sdbl
+	строка" КАК Поле
+//  ^ string.quoted.double.sdbl

--- a/spec/fixtures/grammar/syntax_test_sdbl.txt
+++ b/spec/fixtures/grammar/syntax_test_sdbl.txt
@@ -9,5 +9,33 @@
 //  ^ comment.line.double-slash.sdbl
     с экранированной "" кавычкой
 //                   ^^ constant.character.escape.sdbl
-	строка" КАК Поле
+    строка" КАК Поле,
+//  ^^^^^^^ string.quoted.double.sdbl
 //  ^ string.quoted.double.sdbl
+//          ^^^ keyword.control.sdbl
+//              ^ not:keyword.control.sdbl
+//                  ^ keyword.operator.sdbl
+    Неопределено КАК Поле2,
+//  ^ constant.language.sdbl
+    0.0 КАК ДробноеЧисло,
+//  ^^^ constant.numeric.sdbl
+    0 КАК ЦелоеЧисло,
+//  ^ constant.numeric.sdbl
+    ВЫБОР КОГДА НЕ 0 = 0 * 1 ТОГДА ИСТИНА ИНАЧЕ ЛОЖЬ КОНЕЦ КАК Условие,
+//  ^^^^^ keyword.control.conditional.sdbl
+//        ^^^^^ keyword.control.conditional.sdbl
+//              ^^ keyword.operator.logical.sdbl
+//                   ^ keyword.operator.comparison.sdbl
+//                       ^ keyword.operator.arithmetic.sdbl
+//                           ^^^^^ keyword.control.conditional.sdbl
+//                                        ^^^^^ keyword.control.conditional.sdbl
+//                                                   ^^^^^ keyword.control.conditional.sdbl
+    ГОД(ДАТАВРЕМЯ(1, 1, 1)) КАК Функция,
+//  ^^^ support.function.sdbl
+//     ^ not:support.function.sdbl
+//      ^ support.function.sdbl
+    ВЫРАЗИТЬ(0 КАК Число) КАК Выражение,
+//  ^ keyword.control.sdbl
+//                 ^^^^^ support.type.sdbl
+    &Параметр КАК Параметр
+//  ^^^^^^^^^ variable.parameter.sdbl

--- a/spec/language-1s-bsl-spec.coffee
+++ b/spec/language-1s-bsl-spec.coffee
@@ -1,0 +1,10 @@
+grammarTest = require 'atom-grammar-test'
+path = require 'path'
+
+describe "language-1c-bsl", ->
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-1c-bsl')
+
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_bsl.bsl')

--- a/spec/language-1s-bsl-spec.coffee
+++ b/spec/language-1s-bsl-spec.coffee
@@ -9,3 +9,4 @@ describe "language-1c-bsl", ->
 
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_bsl.bsl')
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_bsl.os')
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_sdbl.txt')

--- a/spec/language-1s-bsl-spec.coffee
+++ b/spec/language-1s-bsl-spec.coffee
@@ -8,3 +8,4 @@ describe "language-1c-bsl", ->
       atom.packages.activatePackage('language-1c-bsl')
 
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_bsl.bsl')
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_bsl.os')


### PR DESCRIPTION
По идее это должно закрыть xDrivenDevelopment/1c-syntax#14, если сделать нормальную фикстуру.
Реализация через пакет для Атома может показаться некоторым костылем, но.. надо же с чего-то начать.

Для проверки грамматики используется node-пакет [atom-grammar-test](https://www.npmjs.com/package/atom-grammar-test)
/cc @artbear 